### PR TITLE
Use https submodule location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".fixtures"]
 	path = .fixtures
-	url = git://github.com/dailymotion/cloudkey-fixtures.git
+	url = https://github.com/dailymotion/cloudkey-fixtures.git


### PR DESCRIPTION
A git://github.com/... url requires the user to have a valid ssh key to login to github.com. For instance, the following command fails on a newly created virtual machine:

```
pip install -e git+https://github.com/dailymotion/cloudkey-py@1.2.7#egg=cloudkey
```

Replacing the git:// location by https:// fixes the issue.
